### PR TITLE
[ closes #6] stadium info souvenir list

### DIFF
--- a/src/header/mainwindow.h
+++ b/src/header/mainwindow.h
@@ -13,6 +13,7 @@
 #include "../header/tripsummary.h"
 #include "../header/database.h"
 #include "../header/stadiumtablemodel.h"
+#include "../header/souvenirtablemodel.h"
 #include <QDebug>
 
 namespace Ui {
@@ -41,6 +42,7 @@ public:
 
 signals:
     void initializeStadiumTable(StadiumTableModel *stadiumModel);
+    void initializeSouvenirTable(SouvenirTableModel *souvenirModel);
 
 private slots:
     void on_mainwindow_pushButton_next_clicked();
@@ -64,6 +66,7 @@ private:
     QStack<int>       pageStackCache;
     Database*         db;
     StadiumTableModel* stadiumModel;
+    SouvenirTableModel* souvenirModel;
 
     void checkPage_hideShowBackNextButton();
     void leavingTripSummary();

--- a/src/header/souvenirtablemodel.h
+++ b/src/header/souvenirtablemodel.h
@@ -1,0 +1,28 @@
+#ifndef SOUVENIRTABLEMODEL_H
+#define SOUVENIRTABLEMODEL_H
+
+#include "database.h"
+#include <QSqlTableModel>
+#include <QObject>
+
+class SouvenirTableModel : public QSqlTableModel
+{
+    Q_OBJECT
+public:
+    // fields in table souvenirs
+    enum Fields
+    {
+        STADIUM_ID,
+        NAME,
+        PRICE
+    };
+
+    // Constructor
+    SouvenirTableModel(QObject *parent, Database *db);
+    SouvenirTableModel(QObject *parent, Database *db, int stadiumId);
+
+    // Initialize model settings
+    void Initialize(int stadiumId = -1);
+};
+
+#endif // SOUVENIRTABLEMODEL_H

--- a/src/header/stadiumdetails.h
+++ b/src/header/stadiumdetails.h
@@ -2,7 +2,9 @@
 #define STADIUMDETAILS_H
 
 #include <QWidget>
+#include <QDebug>
 #include "stadiumtablemodel.h"
+#include "souvenirtablemodel.h"
 
 namespace Ui {
 class StadiumDetails;
@@ -14,20 +16,28 @@ class StadiumDetails : public QWidget
 
 public:
     explicit StadiumDetails(QWidget *parent = 0);
+
     void initializeStadiumView();
+
+    void initializeSouvenirView();
+
     ~StadiumDetails();
 
 public slots:
     void initializeStadiumTable(StadiumTableModel *stadiumModel);
+    void initializeSouvenirTable(SouvenirTableModel *souvenirModel);
 
 private slots:
     void on_stadiumDetails_league_comboBox_currentIndexChanged(int index);
 
     void on_stadiumDetails_surface_comboBox_currentIndexChanged(int index);
 
+    void on_stadiumDetails_tableView_stadiumInfo_clicked(const QModelIndex &index);
+
 private:
     Ui::StadiumDetails *ui;
     StadiumTableModel *stadiumModel;
+    SouvenirTableModel *souvenirModel;
 };
 
 #endif // STADIUMDETAILS_H

--- a/src/header/stadiumdetails.h
+++ b/src/header/stadiumdetails.h
@@ -34,6 +34,8 @@ private slots:
 
     void on_stadiumDetails_tableView_stadiumInfo_clicked(const QModelIndex &index);
 
+    void on_stadiumDetails_tableView_stadiumInfo_activated(const QModelIndex &index);
+
 private:
     Ui::StadiumDetails *ui;
     StadiumTableModel *stadiumModel;

--- a/src/source/mainwindow.cpp
+++ b/src/source/mainwindow.cpp
@@ -30,6 +30,8 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(tripSummary_widget, SIGNAL(finishTrip(bool)), this, SLOT(gotoHomePage()));
     connect(this, SIGNAL(initializeStadiumTable(StadiumTableModel*)),
             stadiumDetails_widget, SLOT(initializeStadiumTable(StadiumTableModel*)));
+    connect(this, SIGNAL(initializeSouvenirTable(SouvenirTableModel*)),
+            stadiumDetails_widget, SLOT(initializeSouvenirTable(SouvenirTableModel*)));
 
     // toggle hiding of back/next button
     checkPage_hideShowBackNextButton();
@@ -165,7 +167,9 @@ void MainWindow::on_mainwindow_pushButton_viewStadiums_clicked()
 
     // initialize tables with data from database
     stadiumModel = new StadiumTableModel(this, db);
+    souvenirModel = new SouvenirTableModel(this, db);
     emit initializeStadiumTable(stadiumModel);
+    emit initializeSouvenirTable(souvenirModel);
 
 }
 
@@ -181,7 +185,7 @@ void MainWindow::leavingTripSummary()
  */
 void MainWindow::gotoHomePage()
 {
-    /// TODO: CLEAR DATA IN ALL CURRENT WIDGETS
+    // TODO: CLEAR DATA IN ALL CURRENT WIDGETS
     ui->mainwindow_stackedWidget->setCurrentIndex(PAGE_MAIN);
     checkPage_hideShowBackNextButton();
     pageStackCache.clear();

--- a/src/source/souvenirtablemodel.cpp
+++ b/src/source/souvenirtablemodel.cpp
@@ -1,0 +1,30 @@
+#include "header/souvenirtablemodel.h"
+
+SouvenirTableModel::SouvenirTableModel(QObject *parent, Database *db) : QSqlTableModel(parent, *db)
+{
+    Initialize();
+}
+
+SouvenirTableModel::SouvenirTableModel(QObject *parent, Database *db, int stadiumId) : QSqlTableModel(parent, *db)
+{
+    Initialize(stadiumId);
+}
+
+void SouvenirTableModel::Initialize(int stadiumId)
+{
+    // set which SQL table to display
+    this->setTable("souvenirs");
+
+    // make table only push changes to DB on manual submit
+    this->setEditStrategy(QSqlTableModel::OnManualSubmit);
+
+    // set horizontal header titles
+    this->setHeaderData(NAME, Qt::Horizontal, tr("Item Name"), 0);
+    this->setHeaderData(PRICE, Qt::Horizontal, tr("Item Price"), 0);
+
+    this->setFilter("stadium_id = " + QString::number(stadiumId));
+
+    // propagate model
+    this->select();
+
+}

--- a/src/source/stadiumdetails.cpp
+++ b/src/source/stadiumdetails.cpp
@@ -42,6 +42,39 @@ void StadiumDetails::initializeStadiumView()
     ui->stadiumDetails_tableView_stadiumInfo->setColumnHidden(StadiumTableModel::ID, true);
 }
 
+void StadiumDetails::initializeSouvenirView()
+{
+    // hide vertical header
+    ui->stadiumDetails_tableView_souvenirs->verticalHeader()->setVisible(false);
+
+    // turn alternating row colors on
+    ui->stadiumDetails_tableView_souvenirs->setAlternatingRowColors(true);
+
+    // make table uneditable
+    ui->stadiumDetails_tableView_souvenirs->setEditTriggers(QTableView::NoEditTriggers);
+
+    // turn word-wrap on... this might do what we want it to do.. I DON'T KNOW
+    ui->stadiumDetails_tableView_souvenirs->setWordWrap(true);
+
+    // make it so selection selects each row
+    ui->stadiumDetails_tableView_souvenirs->setSelectionBehavior(QAbstractItemView::SelectRows);
+
+    // make it so only one stadium row can be selected at a time
+    ui->stadiumDetails_tableView_souvenirs->setSelectionMode(QAbstractItemView::SingleSelection);
+
+    // enable sorting
+    ui->stadiumDetails_tableView_souvenirs->setSortingEnabled(true);
+
+    // set headers as not resizable.
+    ui->stadiumDetails_tableView_souvenirs->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
+
+    // hide id column
+    ui->stadiumDetails_tableView_souvenirs->setColumnHidden(SouvenirTableModel::STADIUM_ID, true);
+
+    // stretch the last section of header
+    ui->stadiumDetails_tableView_souvenirs->horizontalHeader()->setStretchLastSection(true);
+}
+
 StadiumDetails::~StadiumDetails()
 {
     delete ui;
@@ -62,6 +95,19 @@ void StadiumDetails::initializeStadiumTable(StadiumTableModel *stadiumModel)
 
     // Initialize table settings.
     initializeStadiumView();
+}
+
+void StadiumDetails::initializeSouvenirTable(SouvenirTableModel *souvenirModel)
+{
+    // Set this class's souvenirModel attribute to the one that's
+    // passed in so we can use it later.
+    this->souvenirModel = souvenirModel;
+
+    // Set the model of the stadiumInfo table
+    ui->stadiumDetails_tableView_souvenirs->setModel(this->souvenirModel);
+
+    // Initialize table settings.
+    initializeSouvenirView();
 }
 
 /**
@@ -250,4 +296,10 @@ void StadiumDetails::on_stadiumDetails_surface_comboBox_currentIndexChanged(int 
         } // end switch
         break;
     } // end switch
+}
+
+void StadiumDetails::on_stadiumDetails_tableView_stadiumInfo_clicked(const QModelIndex &index)
+{
+    int stadium = stadiumModel->record(index.row()).value("id").toInt();
+    souvenirModel->Initialize(stadium);
 }

--- a/src/source/stadiumdetails.cpp
+++ b/src/source/stadiumdetails.cpp
@@ -42,6 +42,10 @@ void StadiumDetails::initializeStadiumView()
     ui->stadiumDetails_tableView_stadiumInfo->setColumnHidden(StadiumTableModel::ID, true);
 }
 
+/**
+ * @brief StadiumDetails::initializeSouvenirView
+ * Initialize settings for souvenir table view.
+ */
 void StadiumDetails::initializeSouvenirView()
 {
     // hide vertical header
@@ -69,7 +73,7 @@ void StadiumDetails::initializeSouvenirView()
     ui->stadiumDetails_tableView_souvenirs->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
 
     // hide id column
-    ui->stadiumDetails_tableView_souvenirs->setColumnHidden(SouvenirTableModel::STADIUM_ID, true);
+//    ui->stadiumDetails_tableView_souvenirs->setColumnHidden(SouvenirTableModel::STADIUM_ID, true);
 
     // stretch the last section of header
     ui->stadiumDetails_tableView_souvenirs->horizontalHeader()->setStretchLastSection(true);
@@ -97,6 +101,11 @@ void StadiumDetails::initializeStadiumTable(StadiumTableModel *stadiumModel)
     initializeStadiumView();
 }
 
+/**
+ * @brief StadiumDetails::initializeSouvenirTable
+ * Initializes the souvenirTable using the model emitted from mainWindow
+ * @param souvenirModel The model emitted from mainWindow
+ */
 void StadiumDetails::initializeSouvenirTable(SouvenirTableModel *souvenirModel)
 {
     // Set this class's souvenirModel attribute to the one that's
@@ -298,9 +307,32 @@ void StadiumDetails::on_stadiumDetails_surface_comboBox_currentIndexChanged(int 
     } // end switch
 }
 
+/**
+ * @brief StadiumDetails::on_stadiumDetails_tableView_stadiumInfo_clicked
+ * Updates the souvenir table with the appropriate souvenir list
+ * when the user clicks a row in the stadium table.
+ * @param index the index of the selected row
+ */
 void StadiumDetails::on_stadiumDetails_tableView_stadiumInfo_clicked(const QModelIndex &index)
 {
     int stadium = stadiumModel->record(index.row()).value("id").toInt();
+    // Initialize the model to the selected stadium.
     souvenirModel->Initialize(stadium);
+    // Reinitialize the souvenir view.
+    initializeSouvenirView();
+}
+
+/**
+ * @brief StadiumDetails::on_stadiumDetails_tableView_stadiumInfo_activated
+ * Updates the souvenir table with the appropriate souvenir list
+ * when the user presses enter after selecting a row in the stadium table.
+ * @param index the index of the selected row
+ */
+void StadiumDetails::on_stadiumDetails_tableView_stadiumInfo_activated(const QModelIndex &index)
+{
+    int stadium = stadiumModel->record(index.row()).value("id").toInt();
+    // Initialize the model to the selected stadium.
+    souvenirModel->Initialize(stadium);
+    // Reinitialize the souvenir view.
     initializeSouvenirView();
 }

--- a/src/source/stadiumdetails.cpp
+++ b/src/source/stadiumdetails.cpp
@@ -302,4 +302,5 @@ void StadiumDetails::on_stadiumDetails_tableView_stadiumInfo_clicked(const QMode
 {
     int stadium = stadiumModel->record(index.row()).value("id").toInt();
     souvenirModel->Initialize(stadium);
+    initializeSouvenirView();
 }

--- a/src/source/stadiumdetails.cpp
+++ b/src/source/stadiumdetails.cpp
@@ -73,7 +73,7 @@ void StadiumDetails::initializeSouvenirView()
     ui->stadiumDetails_tableView_souvenirs->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
 
     // hide id column
-//    ui->stadiumDetails_tableView_souvenirs->setColumnHidden(SouvenirTableModel::STADIUM_ID, true);
+    ui->stadiumDetails_tableView_souvenirs->setColumnHidden(SouvenirTableModel::STADIUM_ID, true);
 
     // stretch the last section of header
     ui->stadiumDetails_tableView_souvenirs->horizontalHeader()->setStretchLastSection(true);

--- a/src/src.pro
+++ b/src/src.pro
@@ -19,7 +19,8 @@ SOURCES += source/mainwindow.cpp \
     source/purchasewindow.cpp \
     source/editstadiuminfo.cpp \
     source/tripsummary.cpp \
-    source/stadiumtablemodel.cpp
+    source/stadiumtablemodel.cpp \
+    source/souvenirtablemodel.cpp
 
 HEADERS  += header/mainwindow.h \
     header/stadiumdetails.h \
@@ -29,7 +30,8 @@ HEADERS  += header/mainwindow.h \
     header/editstadiuminfo.h \
     header/tripsummary.h \
     header/database.h \
-    header/stadiumtablemodel.h
+    header/stadiumtablemodel.h \
+    header/souvenirtablemodel.h
 
 FORMS    += form/mainwindow.ui \
     form/stadiumdetails.ui \


### PR DESCRIPTION
- Souvenir list now displays under the stadium list on the stadium details page.
- List changes to represent correct list when a user clicks on a stadium row, or selects using the arrow keys and presses enter.
